### PR TITLE
Typo correction for instructions to start the server in a Vagrant installation.

### DIFF
--- a/doc/installation-makahiki-vagrant-quickstart.rst
+++ b/doc/installation-makahiki-vagrant-quickstart.rst
@@ -107,11 +107,11 @@ Switch to /vagrant/makahiki::
 
   vagrant@precise32:/vagrant/$ cd /vagrant/makahiki
   
-To start the server with manage.py::
+To start the runserver server::
 
   vagrant@precise32:/vagrant/makahiki$ ./manage.py runserver 0.0.0.0:8000
 
-To start the server with gunicorn::
+To start the gunicorn server::
 
   vagrant@precise32:/vagrant/makahiki$ ./manage.py run_gunicorn -b 0.0.0.0:8000
 

--- a/doc/installation-makahiki-vagrant-running-makahiki.rst
+++ b/doc/installation-makahiki-vagrant-running-makahiki.rst
@@ -67,11 +67,11 @@ Switch to vagrant/makahiki and run the update_instance.py script::
 
 Start the server with runserver or gunicorn.
 
-To start the server with runserver::
+To start the runserver server::
 
   vagrant@precise32:/vagrant/makahiki$ ./manage.py runserver
 
-To start the server with gunicorn::
+To start the gunicorn server::
 
   vagrant@precise32:/vagrant/makahiki$ ./manage.py run_gunicorn
 


### PR DESCRIPTION
doc/installation-makahiki-vagrant-quickstart.rst, doc/installation-makahiki-vagrant-running-makahiki.rst: Cleaned up wording of instructions to start the server.
