### PR TITLE
Cleaned up Vagrant documentation: installation-makahiki-vagrant-environment-setup.rst

### DIFF
--- a/doc/installation-makahiki-vagrant-environment-setup.rst
+++ b/doc/installation-makahiki-vagrant-environment-setup.rst
@@ -124,14 +124,13 @@ system. See `GitHub's setup guide`_ for instructions.
 .. _Git for Windows: http://git-scm.com/download/win
 .. _Github's setup guide: http://help.github.com/articles/set-up-git
 
-If you have Git for Windows, you should be able to clone the repository from within the Command Prompt.
-If you have Git on Mac OS X or Linux, you should be able to clone the repository from within the Terminal.
-Enter the following command to clone the repository::
+After installing Git or Git for Windows on your operating system, enter the 
+following command in your Command Prompt or Terminal to clone the repository::
 
   > git clone http://github.com/csdl/makahiki.git
 
-.. note:: If you are unable to use the `git clone` command, you will need to use 
-   the Git for Windows command prompt instead.
+.. note:: If the `git clone` command does not work in the Windows Command Prompt, 
+   you will need to use the Git for Windows terminal instead.
 
 Install Makahiki On Vagrant
 ---------------------------


### PR DESCRIPTION
Fixed unclear instructions:
- Instructions now specify that Windows users with "Git for Windows" should be able to do a `git clone` with the normal command prompt without using Git for Windows
- User is now instructed to switch to the directory they would like to install Makahiki into before cloning the repository or moving the .zip file. 
